### PR TITLE
Add Windows setup script instructions

### DIFF
--- a/Respuesta al usuario
+++ b/Respuesta al usuario
@@ -1,0 +1,17 @@
+Sí, es posible crear un script .bat para automatizar la instalación y actualización en Windows. Un ejemplo básico sería:
+
+@echo off
+REM Actualiza el repositorio
+git pull
+
+REM Crea un entorno virtual
+python -m venv venv
+call venv\Scripts\activate
+
+REM Instala Basic Pitch (y TensorFlow si se desea)
+pip install --upgrade pip
+pip install basic-pitch
+REM Para instalar con TensorFlow: pip install "basic-pitch[tf]"
+
+REM Ejemplo de uso: procesar un archivo de audio
+REM basic-pitch salida\ carpeta\input.wav


### PR DESCRIPTION
## Summary
- add Spanish instructions for a Windows installation script

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'apache_beam')*

------
https://chatgpt.com/codex/tasks/task_e_684cd7e29d34832ba2bed051d6c211c5