### PR TITLE
Add simple Gradio demo and launcher

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,23 @@
+import gradio as gr
+from basic_pitch.inference import predict_and_save
+import os
+import tempfile
+
+
+def transcribir(audio):
+    tmpdir = tempfile.mkdtemp()
+    predict_and_save(
+        [audio],
+        tmpdir,
+        save_midi=True,
+        sonify_midi=False,
+        save_model_outputs=False,
+        save_notes=False,
+    )
+    midi = os.path.join(tmpdir, os.path.splitext(os.path.basename(audio))[0] + ".mid")
+    return midi
+
+
+gr.Interface(
+    fn=transcribir, inputs=gr.Audio(type="filepath"), outputs=gr.File()
+).launch()

--- a/run_app.bat
+++ b/run_app.bat
@@ -1,0 +1,20 @@
+@echo off
+REM Navigate to script directory
+cd /d %~dp0
+
+REM Create virtual environment if not already present
+if not exist venv (
+    python -m venv venv
+)
+
+REM Activate virtual environment
+call venv\Scripts\activate
+
+REM Upgrade pip and install dependencies
+pip install --upgrade pip
+pip install basic-pitch gradio
+
+REM Run the Gradio application
+python app.py
+
+pause


### PR DESCRIPTION
## Summary
- add `app.py` with a gradio transcription interface
- add `run_app.bat` for Windows users to set up a venv and run the demo

## Testing
- `black app.py --check`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'apache_beam')*
- `tox -q -s` *(fails: exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_684ce10e9844832ba8070f9e875429f0