### PR TITLE
Fix app usage for predict_and_save

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ predict_and_save(
     <sonify-midi>,
     <save-model-outputs>,
     <save-notes>,
+    <model-or-model-path>,
 )
 ```
 
@@ -170,6 +171,8 @@ where:
         - *bool* to control saving the raw model output as a NPZ file to the `<output-directory>`
    - `<save-notes>`
         - *bool* to control saving predicted note events as a CSV file `<output-directory>`
+   - `<model-or-model-path>`
+        - path to a serialized model or a loaded `Model` instance
 
 
 

--- a/app.py
+++ b/app.py
@@ -1,5 +1,6 @@
 import gradio as gr
 from basic_pitch.inference import predict_and_save
+from basic_pitch import ICASSP_2022_MODEL_PATH
 import os
 import tempfile
 
@@ -13,11 +14,10 @@ def transcribir(audio):
         sonify_midi=False,
         save_model_outputs=False,
         save_notes=False,
+        model_or_model_path=ICASSP_2022_MODEL_PATH,
     )
     midi = os.path.join(tmpdir, os.path.splitext(os.path.basename(audio))[0] + ".mid")
     return midi
 
 
-gr.Interface(
-    fn=transcribir, inputs=gr.Audio(type="filepath"), outputs=gr.File()
-).launch()
+gr.Interface(fn=transcribir, inputs=gr.Audio(type="filepath"), outputs=gr.File()).launch()

--- a/basic_pitch/note_creation.py
+++ b/basic_pitch/note_creation.py
@@ -264,7 +264,7 @@ def note_events_to_midi(
 
 
 def drop_overlapping_pitch_bends(
-    note_events_with_pitch_bends: List[Tuple[float, float, int, float, Optional[List[int]]]]
+    note_events_with_pitch_bends: List[Tuple[float, float, int, float, Optional[List[int]]]],
 ) -> List[Tuple[float, float, int, float, Optional[List[int]]]]:
     """Drop pitch bends from any notes that overlap in time with another note"""
     note_events = sorted(note_events_with_pitch_bends)


### PR DESCRIPTION
## Summary
- fix `predict_and_save` call in `app.py`
- document `model-or-model-path` parameter in README
- run `black` on updated files

## Testing
- `black app.py basic_pitch/note_creation.py --line-length 120`
- `python -m flake8`
- `python -m mypy basic_pitch tests` *(fails: cannot find stubs)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'basic_pitch')*

------
https://chatgpt.com/codex/tasks/task_e_684ce4fd2d54832bb35ee2381f86f009