### PR TITLE
Improve pitch detection parameters

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,9 +1,21 @@
+import argparse
 import gradio as gr
 from basic_pitch.inference import predict_and_save
 from basic_pitch import ICASSP_2022_MODEL_PATH
 import pretty_midi
 import os
 import tempfile
+
+
+parser = argparse.ArgumentParser(description="Basic Pitch Gradio app")
+parser.add_argument("--onset-threshold", type=float, default=0.6)
+parser.add_argument("--frame-threshold", type=float, default=0.4)
+parser.add_argument("--minimum-note-length", type=float, default=200.0)
+parser.add_argument("--minimum-frequency", type=float, default=55.0)
+parser.add_argument("--maximum-frequency", type=float, default=1760.0)
+parser.add_argument("--multiple-pitch-bends", action="store_true")
+parser.add_argument("--no-melodia", action="store_true")
+args = parser.parse_args()
 
 
 def transcribir(audio):
@@ -16,6 +28,13 @@ def transcribir(audio):
         save_model_outputs=False,
         save_notes=False,
         model_or_model_path=ICASSP_2022_MODEL_PATH,
+        onset_threshold=args.onset_threshold,
+        frame_threshold=args.frame_threshold,
+        minimum_note_length=args.minimum_note_length,
+        minimum_frequency=args.minimum_frequency,
+        maximum_frequency=args.maximum_frequency,
+        multiple_pitch_bends=args.multiple_pitch_bends,
+        melodia_trick=not args.no_melodia,
     )
     midi = os.path.join(
         tmpdir,

--- a/run_app.bat
+++ b/run_app.bat
@@ -14,7 +14,7 @@ REM Upgrade pip and install dependencies
 pip install --upgrade pip
 pip install basic-pitch gradio
 
-REM Run the Gradio application
-python app.py
+REM Run the Gradio application with tuned parameters
+python app.py --onset-threshold 0.6 --frame-threshold 0.4 --minimum-note-length 200 --minimum-frequency 55 --maximum-frequency 1760 --multiple-pitch-bends
 
 pause


### PR DESCRIPTION
## Summary
- add CLI parsing to the app so we can tune pitch detection
- use tuned arguments in the Windows batch file

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'apache_beam')*

------
https://chatgpt.com/codex/tasks/task_e_684cefd75170832ba80f3904f4a8fc03