### PR TITLE
Add melody key detection utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,17 @@ where:
         - path to a serialized model or a loaded `Model` instance
 
 
+### Key Detection
+
+You can estimate the musical key of an audio file using the `detect_key.py` helper script:
+
+```bash
+python detect_key.py <input-audio-path>
+```
+
+The script prints the detected key such as `C major` or `A minor`.
+
+
 
 ### Model Input
 

--- a/basic_pitch/__init__.py
+++ b/basic_pitch/__init__.py
@@ -93,3 +93,7 @@ def build_icassp_2022_model_path(suffix: FilenameSuffix) -> pathlib.Path:
 
 
 ICASSP_2022_MODEL_PATH = build_icassp_2022_model_path(_default_model_type)
+
+# Utility function for estimating the key of a melody
+from .key_detection import detect_key_from_note_events
+

--- a/basic_pitch/key_detection.py
+++ b/basic_pitch/key_detection.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pretty_midi
+from typing import List, Tuple, Optional
+
+MAJOR_PROFILE = np.array([6.35, 2.23, 3.48, 2.33, 4.38, 4.09, 2.52, 5.19, 2.39, 3.66, 2.29, 2.88])
+MINOR_PROFILE = np.array([6.33, 2.68, 3.52, 5.38, 2.60, 3.53, 2.54, 4.75, 3.98, 2.69, 3.34, 3.17])
+
+NoteEvent = Tuple[float, float, int, float, Optional[List[int]]]
+
+def _pitch_class_distribution(note_events: List[NoteEvent]) -> np.ndarray:
+    """Return duration weighted pitch class distribution."""
+    pc = np.zeros(12)
+    for start, end, pitch, _amp, _pb in note_events:
+        duration = max(0.0, end - start)
+        pc[pitch % 12] += duration
+    return pc
+
+def detect_key_from_note_events(note_events: List[NoteEvent]) -> Optional[str]:
+    """Estimate key from note events using a simple Krumhansl-Schmuckler profile."""
+    pc = _pitch_class_distribution(note_events)
+    if pc.sum() == 0:
+        return None
+    pc = pc / np.linalg.norm(pc)
+    best_score = -np.inf
+    best_key = None
+    for tonic in range(12):
+        prof = np.roll(MAJOR_PROFILE, tonic)
+        score = np.dot(pc, prof / np.linalg.norm(prof))
+        if score > best_score:
+            best_score = score
+            best_key = (tonic, "major")
+    for tonic in range(12):
+        prof = np.roll(MINOR_PROFILE, tonic)
+        score = np.dot(pc, prof / np.linalg.norm(prof))
+        if score > best_score:
+            best_score = score
+            best_key = (tonic, "minor")
+    tonic_name = pretty_midi.note_number_to_name(60 + best_key[0])[:-1]
+    return f"{tonic_name} {best_key[1]}"

--- a/detect_key.py
+++ b/detect_key.py
@@ -1,0 +1,25 @@
+import argparse
+from basic_pitch.inference import predict
+from basic_pitch import ICASSP_2022_MODEL_PATH
+from basic_pitch.key_detection import detect_key_from_note_events
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Detect key of a melody")
+    parser.add_argument("audio_path", help="Path to the audio file")
+    args = parser.parse_args()
+
+    _, _, note_events = predict(
+        args.audio_path,
+        model_or_model_path=ICASSP_2022_MODEL_PATH,
+    )
+
+    key = detect_key_from_note_events(note_events)
+    if key is None:
+        print("Could not detect key")
+    else:
+        print(f"Detected key: {key}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `detect_key_from_note_events` helper in `basic_pitch.key_detection`
- expose utility in `basic_pitch.__init__`
- add script `detect_key.py` for CLI key detection
- document feature in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'apache_beam')*

------
https://chatgpt.com/codex/tasks/task_e_684cf38d2274832b8825677134424368