### PR TITLE
Add requirements file and update demo instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,13 @@ we recommend that you cite the version of the code that was used.**
 If, for whatever reason, you're not yet completely inspired, or you're just like so totally over the general vibe and stuff, checkout our snappy demo website, [basicpitch.io](https://basicpitch.io), to experiment with our model on whatever music audio you provide!
 
 ### Local Gradio Demo
-To experiment locally you can run `python app.py`. This launches a Gradio interface with two tabs:
+Install the required dependencies first:
+
+```bash
+pip install -r requirements.txt
+```
+
+Then run `python app.py` to launch a Gradio interface with two tabs:
 
 - **Transcribir Audio**: upload an audio file and receive a MIDI file and a simple preview of the transcription.
 - The interface also displays the detected key and, when possible, a basic chord progression.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+basic-pitch[tf]
+gradio


### PR DESCRIPTION
## Summary
- add `requirements.txt` for running the demo
- document installation step for the Gradio demo

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'apache_beam')*

------
https://chatgpt.com/codex/tasks/task_e_684cfccbd188832ba3c586b88c24342b