### PR TITLE
Fix chord detection without music21

### DIFF
--- a/basic_pitch/chord_detection.py
+++ b/basic_pitch/chord_detection.py
@@ -1,17 +1,43 @@
-import tempfile
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 
-from music21 import converter, chord
+import pretty_midi
 
 
 ChordEvent = Tuple[float, str]
 
 
+CHORD_TEMPLATES = {
+    (0, 4, 7): "major",
+    (0, 3, 7): "minor",
+    (0, 4, 7, 10): "7",
+    (0, 3, 7, 10): "m7",
+    (0, 4, 7, 11): "maj7",
+    (0, 3, 6): "dim",
+    (0, 4, 8): "aug",
+}
+
+
+def _classify_chord(pitch_classes: List[int]) -> Optional[str]:
+    """Return a chord name for the given pitch classes if recognized."""
+    pitch_classes = sorted(set(pitch_classes))
+    for root in pitch_classes:
+        intervals = tuple(sorted(((pc - root) % 12 for pc in pitch_classes)))
+        for template, name in CHORD_TEMPLATES.items():
+            if intervals == template:
+                root_name = pretty_midi.note_number_to_name(root + 60)[:-1]
+                if name == "major":
+                    return f"{root_name} major"
+                if name == "minor":
+                    return f"{root_name} minor"
+                return f"{root_name}{name}"
+    return None
+
+
 def detect_chords_from_midi(midi_path: str) -> List[ChordEvent]:
     """Estimate a simple chord progression from a MIDI file.
 
-    This function uses :mod:`music21` to chordify the MIDI data and extracts
-    the name of each chord along with its offset time in seconds.
+    This function groups active notes between onset/offset boundaries and
+    matches the resulting pitch classes to a small set of chord templates.
     Chords with fewer than two pitches are ignored.
 
     Parameters
@@ -24,12 +50,23 @@ def detect_chords_from_midi(midi_path: str) -> List[ChordEvent]:
     List[ChordEvent]
         A list of ``(time, chord_name)`` tuples.
     """
-    score = converter.parse(midi_path)
-    chordified = score.chordify()
+    pm = pretty_midi.PrettyMIDI(midi_path)
+    notes = [n for inst in pm.instruments for n in inst.notes]
+    if not notes:
+        return []
+
+    times = sorted(set([n.start for n in notes] + [n.end for n in notes]))
     progression: List[ChordEvent] = []
-    for c in chordified.flat.getElementsByClass(chord.Chord):
-        if len(c.pitches) < 2:
+    for i in range(len(times) - 1):
+        t = times[i]
+        active = [n for n in notes if n.start <= t < n.end]
+        if len(active) < 2:
             continue
-        name = c.pitchedCommonName or c.commonName or "unknown"
-        progression.append((float(c.offset), name))
+        pcs = [n.pitch % 12 for n in active]
+        name = _classify_chord(pcs)
+        if not name:
+            continue
+        if not progression or progression[-1][1] != name:
+            progression.append((t, name))
+
     return progression


### PR DESCRIPTION
## Summary
- reimplement chord detection using pretty_midi instead of music21
- provide small chord template matching

## Testing
- `pytest tests/test_chord_detection.py::test_detect_chords_simple -q`

------
https://chatgpt.com/codex/tasks/task_e_684cfe103578832bbd32755606806f82